### PR TITLE
Improve automatic-accessors

### DIFF
--- a/examples/accessors_attr/Cargo.toml
+++ b/examples/accessors_attr/Cargo.toml
@@ -1,0 +1,41 @@
+[package]
+name = "accessors_attr"
+version = "3.1.1"
+authors = ["Brushfam <green@727.ventures>"]
+edition = "2021"
+
+[dependencies]
+ink = { version = "4.2.0", default-features = false}
+
+scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
+scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
+
+# These dependencies
+openbrush = { path = "../..", default-features = false }
+
+[dev-dependencies]
+ink_e2e = "4.2"
+test_helpers = { path = "../test_helpers", default-features = false }
+
+[lib]
+name = "accessors_attr"
+path = "lib.rs"
+crate-type = [
+    # Used for normal contract Wasm blobs.
+    "cdylib",
+]
+
+[features]
+default = ["std"]
+std = [
+    "ink/std",
+    "scale/std",
+    "scale-info/std",
+    # These dependencies
+    "openbrush/std",
+]
+ink-as-dependency = []
+e2e-tests = []
+
+[profile.dev]
+codegen-units = 16

--- a/examples/accessors_attr/lib.rs
+++ b/examples/accessors_attr/lib.rs
@@ -1,0 +1,208 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+#![feature(min_specialization)]
+
+pub use accessors_attr::*;
+
+#[openbrush::contract]
+pub mod accessors_attr {
+    use openbrush::{
+        traits::{
+            Storage,
+            String,
+        },
+    };
+
+    #[ink(storage)]
+    #[derive(Storage)]
+    pub struct Contract {
+        // fields for hater logic
+        #[storage_field]
+        hated_logic: HatedLogic,
+    }
+
+    #[openbrush::upgradeable_storage(STORAGE_KEY)]
+    #[openbrush::accessors(HatedLogicAccessors)]
+    #[derive(Storage)]
+    #[derive(Debug)]
+    pub struct HatedLogic {
+        #[get]
+        #[set]
+        dumb_g_s: u32,
+        #[get]
+        dumb_g_only: u32,
+        #[set]
+        dumb_s_only: u32,
+    }
+
+    pub const STORAGE_KEY: u32 = openbrush::storage_unique_key!(HatedLogic);
+
+    impl HatedLogicAccessors for Contract {}
+
+    impl Contract {
+        #[ink(constructor)]
+        pub fn new() -> Self {
+            let instance = Self {
+                hated_logic: HatedLogic {
+                    dumb_g_s: 0,
+                    dumb_g_only: 0,
+                    dumb_s_only: 0
+                },
+            };
+            instance
+        }
+        #[ink(message)]
+        pub fn update_dumb_g(&mut self, value: u32) {
+            self.hated_logic.dumb_g_only = value
+        }
+        #[ink(message)]
+        pub fn return_dumb_s(&self) -> u32 {
+            self.hated_logic.dumb_s_only
+        }
+    }
+
+    #[cfg(all(test, feature = "e2e-tests"))]
+    pub mod tests {
+        use crate::accessors_attr::hatedlogicaccessors_external::HatedLogicAccessors;
+        #[rustfmt::skip]
+        use super::*;
+        #[rustfmt::skip]
+        use ink_e2e::{build_message, PolkadotConfig};
+
+        type E2EResult<T> = Result<T, Box<dyn std::error::Error>>;
+
+        #[ink_e2e::test]
+        async fn  get_and_set() -> E2EResult<()> {
+            let constructor = ContractRef::new();
+            let address = client
+                .instantiate("accessors_attr", &ink_e2e::alice(), constructor, 0, None)
+                .await
+                .expect("instantiate failed")
+                .account_id;
+
+            let result = {
+                let _msg = build_message::<ContractRef>(address.clone())
+                    .call(|contract| contract.get_dumb_g_s());
+                client
+                    .call(&ink_e2e::alice(), _msg, 0, None)
+                    .await
+                    .expect("get_dumb_g_s failed")
+            };
+
+            assert!(matches!(result.return_value(), 0));
+
+            let result = {
+                let _msg = build_message::<ContractRef>(address.clone())
+                    .call(|contract| contract.set_dumb_g_s(10));
+                client
+                    .call(&ink_e2e::alice(), _msg, 0, None)
+                    .await
+                    .expect("update_dumb_g_only failed")
+            };
+
+            assert!(matches!(result.return_value(), ()));
+
+            let result = {
+                let _msg = build_message::<ContractRef>(address.clone())
+                    .call(|contract| contract.get_dumb_g_s());
+                client
+                    .call(&ink_e2e::alice(), _msg, 0, None)
+                    .await
+                    .expect("get_dumb_g_only failed")
+            };
+
+            assert!(matches!(result.return_value(), 10));
+
+            Ok(())
+        }
+
+        // #[ink_e2e::test]
+        // async fn  only_set() -> E2EResult<()> {
+        //     let constructor = ContractRef::new();
+        //     let address = client
+        //         .instantiate("accessors_attr", &ink_e2e::alice(), constructor, 0, None)
+        //         .await
+        //         .expect("instantiate failed")
+        //         .account_id;
+        //
+        //     let result = {
+        //         let _msg = build_message::<ContractRef>(address.clone())
+        //             .call(|contract| contract.return_dumb_s());
+        //         client
+        //             .call(&ink_e2e::alice(), _msg, 0, None)
+        //             .await
+        //             .expect("return_dumb_s failed")
+        //     };
+        //
+        //     assert!(matches!(result.return_value(), 0));
+        //
+        //     let result = {
+        //         let _msg = build_message::<ContractRef>(address.clone())
+        //             .call(|contract| contract.set_dumb_s_only(10));
+        //         client
+        //             .call(&ink_e2e::alice(), _msg, 0, None)
+        //             .await
+        //             .expect("set_dumb_s_only failed")
+        //     };
+        //
+        //     assert!(matches!(result.return_value(), ()));
+        //
+        //     let result = {
+        //         let _msg = build_message::<ContractRef>(address.clone())
+        //             .call(|contract| contract.return_dumb_s());
+        //         client
+        //             .call(&ink_e2e::alice(), _msg, 0, None)
+        //             .await
+        //             .expect("return_dumb_s failed")
+        //     };
+        //
+        //     assert!(matches!(result.return_value(), 10));
+        //
+        //     Ok(())
+        // }
+        //
+        // #[ink_e2e::test]
+        // async fn  only_get() -> E2EResult<()> {
+        //     let constructor = ContractRef::new();
+        //     let address = client
+        //         .instantiate("accessors_attr", &ink_e2e::alice(), constructor, 0, None)
+        //         .await
+        //         .expect("instantiate failed")
+        //         .account_id;
+        //
+        //     let result = {
+        //         let _msg = build_message::<ContractRef>(address.clone())
+        //             .call(|contract| contract.get_dumb_g_only());
+        //         client
+        //             .call(&ink_e2e::alice(), _msg, 0, None)
+        //             .await
+        //             .expect("get_dumb_g_only failed")
+        //     };
+        //
+        //     assert!(matches!(result.return_value(), 0));
+        //
+        //     let result = {
+        //         let _msg = build_message::<ContractRef>(address.clone())
+        //             .call(|contract| contract.update_dumb_g(10));
+        //         client
+        //             .call(&ink_e2e::alice(), _msg, 0, None)
+        //             .await
+        //             .expect("update_dumb_g_only failed")
+        //     };
+        //
+        //     assert!(matches!(result.return_value(), ()));
+        //
+        //     let result = {
+        //         let _msg = build_message::<ContractRef>(address.clone())
+        //             .call(|contract| contract.get_dumb_g_only());
+        //         client
+        //             .call(&ink_e2e::alice(), _msg, 0, None)
+        //             .await
+        //             .expect("get_dumb_g_only failed")
+        //     };
+        //
+        //     assert!(matches!(result.return_value(), 10));
+        //
+        //     Ok(())
+        // }
+    }
+}

--- a/examples/accessors_attr/lib.rs
+++ b/examples/accessors_attr/lib.rs
@@ -8,7 +8,6 @@ pub mod accessors_attr {
     use openbrush::{
         traits::{
             Storage,
-            String,
         },
     };
 
@@ -17,14 +16,14 @@ pub mod accessors_attr {
     pub struct Contract {
         // fields for hater logic
         #[storage_field]
-        hated_logic: HatedLogic,
+        hated_logic: DumbData,
     }
 
     #[openbrush::upgradeable_storage(STORAGE_KEY)]
-    #[openbrush::accessors(HatedLogicAccessors)]
+    #[openbrush::accessors(DumbDataAccessors)]
     #[derive(Storage)]
     #[derive(Debug)]
-    pub struct HatedLogic {
+    pub struct DumbData {
         #[get]
         #[set]
         dumb_g_s: u32,
@@ -34,15 +33,15 @@ pub mod accessors_attr {
         dumb_s_only: u32,
     }
 
-    pub const STORAGE_KEY: u32 = openbrush::storage_unique_key!(HatedLogic);
+    pub const STORAGE_KEY: u32 = openbrush::storage_unique_key!(DumbData);
 
-    impl HatedLogicAccessors for Contract {}
+    impl DumbDataAccessors for Contract {}
 
     impl Contract {
         #[ink(constructor)]
         pub fn new() -> Self {
             let instance = Self {
-                hated_logic: HatedLogic {
+                hated_logic: DumbData {
                     dumb_g_s: 0,
                     dumb_g_only: 0,
                     dumb_s_only: 0
@@ -62,11 +61,11 @@ pub mod accessors_attr {
 
     #[cfg(all(test, feature = "e2e-tests"))]
     pub mod tests {
-        use crate::accessors_attr::hatedlogicaccessors_external::HatedLogicAccessors;
+        use crate::accessors_attr::dumbdataaccessors_external::DumbDataAccessors;
         #[rustfmt::skip]
         use super::*;
         #[rustfmt::skip]
-        use ink_e2e::{build_message, PolkadotConfig};
+        use ink_e2e::{build_message};
 
         type E2EResult<T> = Result<T, Box<dyn std::error::Error>>;
 

--- a/examples/accessors_attr/lib.rs
+++ b/examples/accessors_attr/lib.rs
@@ -115,94 +115,94 @@ pub mod accessors_attr {
             Ok(())
         }
 
-        // #[ink_e2e::test]
-        // async fn  only_set() -> E2EResult<()> {
-        //     let constructor = ContractRef::new();
-        //     let address = client
-        //         .instantiate("accessors_attr", &ink_e2e::alice(), constructor, 0, None)
-        //         .await
-        //         .expect("instantiate failed")
-        //         .account_id;
-        //
-        //     let result = {
-        //         let _msg = build_message::<ContractRef>(address.clone())
-        //             .call(|contract| contract.return_dumb_s());
-        //         client
-        //             .call(&ink_e2e::alice(), _msg, 0, None)
-        //             .await
-        //             .expect("return_dumb_s failed")
-        //     };
-        //
-        //     assert!(matches!(result.return_value(), 0));
-        //
-        //     let result = {
-        //         let _msg = build_message::<ContractRef>(address.clone())
-        //             .call(|contract| contract.set_dumb_s_only(10));
-        //         client
-        //             .call(&ink_e2e::alice(), _msg, 0, None)
-        //             .await
-        //             .expect("set_dumb_s_only failed")
-        //     };
-        //
-        //     assert!(matches!(result.return_value(), ()));
-        //
-        //     let result = {
-        //         let _msg = build_message::<ContractRef>(address.clone())
-        //             .call(|contract| contract.return_dumb_s());
-        //         client
-        //             .call(&ink_e2e::alice(), _msg, 0, None)
-        //             .await
-        //             .expect("return_dumb_s failed")
-        //     };
-        //
-        //     assert!(matches!(result.return_value(), 10));
-        //
-        //     Ok(())
-        // }
-        //
-        // #[ink_e2e::test]
-        // async fn  only_get() -> E2EResult<()> {
-        //     let constructor = ContractRef::new();
-        //     let address = client
-        //         .instantiate("accessors_attr", &ink_e2e::alice(), constructor, 0, None)
-        //         .await
-        //         .expect("instantiate failed")
-        //         .account_id;
-        //
-        //     let result = {
-        //         let _msg = build_message::<ContractRef>(address.clone())
-        //             .call(|contract| contract.get_dumb_g_only());
-        //         client
-        //             .call(&ink_e2e::alice(), _msg, 0, None)
-        //             .await
-        //             .expect("get_dumb_g_only failed")
-        //     };
-        //
-        //     assert!(matches!(result.return_value(), 0));
-        //
-        //     let result = {
-        //         let _msg = build_message::<ContractRef>(address.clone())
-        //             .call(|contract| contract.update_dumb_g(10));
-        //         client
-        //             .call(&ink_e2e::alice(), _msg, 0, None)
-        //             .await
-        //             .expect("update_dumb_g_only failed")
-        //     };
-        //
-        //     assert!(matches!(result.return_value(), ()));
-        //
-        //     let result = {
-        //         let _msg = build_message::<ContractRef>(address.clone())
-        //             .call(|contract| contract.get_dumb_g_only());
-        //         client
-        //             .call(&ink_e2e::alice(), _msg, 0, None)
-        //             .await
-        //             .expect("get_dumb_g_only failed")
-        //     };
-        //
-        //     assert!(matches!(result.return_value(), 10));
-        //
-        //     Ok(())
-        // }
+        #[ink_e2e::test]
+        async fn  only_set() -> E2EResult<()> {
+            let constructor = ContractRef::new();
+            let address = client
+                .instantiate("accessors_attr", &ink_e2e::alice(), constructor, 0, None)
+                .await
+                .expect("instantiate failed")
+                .account_id;
+
+            let result = {
+                let _msg = build_message::<ContractRef>(address.clone())
+                    .call(|contract| contract.return_dumb_s());
+                client
+                    .call(&ink_e2e::alice(), _msg, 0, None)
+                    .await
+                    .expect("return_dumb_s failed")
+            };
+
+            assert!(matches!(result.return_value(), 0));
+
+            let result = {
+                let _msg = build_message::<ContractRef>(address.clone())
+                    .call(|contract| contract.set_dumb_s_only(10));
+                client
+                    .call(&ink_e2e::alice(), _msg, 0, None)
+                    .await
+                    .expect("set_dumb_s_only failed")
+            };
+
+            assert!(matches!(result.return_value(), ()));
+
+            let result = {
+                let _msg = build_message::<ContractRef>(address.clone())
+                    .call(|contract| contract.return_dumb_s());
+                client
+                    .call(&ink_e2e::alice(), _msg, 0, None)
+                    .await
+                    .expect("return_dumb_s failed")
+            };
+
+            assert!(matches!(result.return_value(), 10));
+
+            Ok(())
+        }
+
+        #[ink_e2e::test]
+        async fn  only_get() -> E2EResult<()> {
+            let constructor = ContractRef::new();
+            let address = client
+                .instantiate("accessors_attr", &ink_e2e::alice(), constructor, 0, None)
+                .await
+                .expect("instantiate failed")
+                .account_id;
+
+            let result = {
+                let _msg = build_message::<ContractRef>(address.clone())
+                    .call(|contract| contract.get_dumb_g_only());
+                client
+                    .call(&ink_e2e::alice(), _msg, 0, None)
+                    .await
+                    .expect("get_dumb_g_only failed")
+            };
+
+            assert!(matches!(result.return_value(), 0));
+
+            let result = {
+                let _msg = build_message::<ContractRef>(address.clone())
+                    .call(|contract| contract.update_dumb_g(10));
+                client
+                    .call(&ink_e2e::alice(), _msg, 0, None)
+                    .await
+                    .expect("update_dumb_g_only failed")
+            };
+
+            assert!(matches!(result.return_value(), ()));
+
+            let result = {
+                let _msg = build_message::<ContractRef>(address.clone())
+                    .call(|contract| contract.get_dumb_g_only());
+                client
+                    .call(&ink_e2e::alice(), _msg, 0, None)
+                    .await
+                    .expect("get_dumb_g_only failed")
+            };
+
+            assert!(matches!(result.return_value(), 10));
+
+            Ok(())
+        }
     }
 }

--- a/examples/psp22/lib.rs
+++ b/examples/psp22/lib.rs
@@ -26,11 +26,16 @@ pub mod my_psp22 {
 
     #[openbrush::upgradeable_storage(STORAGE_KEY)]
     #[openbrush::accessors(HatedLogicAccessors)]
+    #[derive(Storage)]
     #[derive(Debug)]
     pub struct HatedLogic {
         #[get]
         #[set]
         hated_account: AccountId,
+        #[get]
+        dumb_g_only: u32,
+        #[set]
+        dumb_s_only: u32,
     }
 
     pub const STORAGE_KEY: u32 = openbrush::storage_unique_key!(HatedLogic);
@@ -61,6 +66,8 @@ pub mod my_psp22 {
                 psp22: Default::default(),
                 hated_logic: HatedLogic {
                     hated_account: [255; 32].into(),
+                    dumb_g_only: 0,
+                    dumb_s_only: 0
                 },
             };
 
@@ -70,11 +77,20 @@ pub mod my_psp22 {
 
             instance
         }
+        #[ink(message)]
+        pub fn update_dumb_g(&mut self, value: u32) {
+            self.hated_logic.dumb_g_only = value
+        }
+        #[ink(message)]
+        pub fn return_dumb_s(&self) -> u32 {
+            self.hated_logic.dumb_s_only
+        }
     }
 
     #[cfg(all(test, feature = "e2e-tests"))]
     pub mod tests {
         use openbrush::contracts::psp22::psp22_external::PSP22;
+        use crate::my_psp22::hatedlogicaccessors_external::HatedLogicAccessors;
         #[rustfmt::skip]
         use super::*;
         #[rustfmt::skip]

--- a/examples/psp22/lib.rs
+++ b/examples/psp22/lib.rs
@@ -222,5 +222,51 @@ pub mod my_psp22 {
 
             Ok(())
         }
+
+        #[ink_e2e::test]
+        async fn  only_set() -> E2EResult<()> {
+            let constructor = ContractRef::new(0);
+            let address = client
+                .instantiate("my_psp22", &ink_e2e::alice(), constructor, 0, None)
+                .await
+                .expect("instantiate failed")
+                .account_id;
+
+            let result = {
+                let _msg = build_message::<ContractRef>(address.clone())
+                    .call(|contract| contract.return_dumb_s());
+                client
+                    .call(&ink_e2e::alice(), _msg, 0, None)
+                    .await
+                    .expect("return_dumb_s failed")
+            };
+
+            assert!(matches!(result.return_value(), 0));
+
+            let result = {
+                let _msg = build_message::<ContractRef>(address.clone())
+                    .call(|contract| contract.set_dumb_s_only(10));
+                client
+                    .call(&ink_e2e::alice(), _msg, 0, None)
+                    .await
+                    .expect("set_dumb_s_only failed")
+            };
+
+            assert!(matches!(result.return_value(), ()));
+
+            let result = {
+                let _msg = build_message::<ContractRef>(address.clone())
+                    .call(|contract| contract.return_dumb_s());
+                client
+                    .call(&ink_e2e::alice(), _msg, 0, None)
+                    .await
+                    .expect("return_dumb_s failed")
+            };
+
+            assert!(matches!(result.return_value(), 10));
+
+            Ok(())
+        }
+
     }
 }

--- a/examples/psp22/lib.rs
+++ b/examples/psp22/lib.rs
@@ -32,10 +32,6 @@ pub mod my_psp22 {
         #[get]
         #[set]
         hated_account: AccountId,
-        #[get]
-        dumb_g_only: u32,
-        #[set]
-        dumb_s_only: u32,
     }
 
     pub const STORAGE_KEY: u32 = openbrush::storage_unique_key!(HatedLogic);
@@ -66,8 +62,6 @@ pub mod my_psp22 {
                 psp22: Default::default(),
                 hated_logic: HatedLogic {
                     hated_account: [255; 32].into(),
-                    dumb_g_only: 0,
-                    dumb_s_only: 0
                 },
             };
 
@@ -76,14 +70,6 @@ pub mod my_psp22 {
                 .expect("Should mint");
 
             instance
-        }
-        #[ink(message)]
-        pub fn update_dumb_g(&mut self, value: u32) {
-            self.hated_logic.dumb_g_only = value
-        }
-        #[ink(message)]
-        pub fn return_dumb_s(&self) -> u32 {
-            self.hated_logic.dumb_s_only
         }
     }
 
@@ -219,96 +205,6 @@ pub mod my_psp22 {
             let balance_of_bob = balance_of!(client, address, bob);
 
             assert!(matches!(balance_of_bob, 10));
-
-            Ok(())
-        }
-
-        #[ink_e2e::test]
-        async fn  only_set() -> E2EResult<()> {
-            let constructor = ContractRef::new(0);
-            let address = client
-                .instantiate("my_psp22", &ink_e2e::alice(), constructor, 0, None)
-                .await
-                .expect("instantiate failed")
-                .account_id;
-
-            let result = {
-                let _msg = build_message::<ContractRef>(address.clone())
-                    .call(|contract| contract.return_dumb_s());
-                client
-                    .call(&ink_e2e::alice(), _msg, 0, None)
-                    .await
-                    .expect("return_dumb_s failed")
-            };
-
-            assert!(matches!(result.return_value(), 0));
-
-            let result = {
-                let _msg = build_message::<ContractRef>(address.clone())
-                    .call(|contract| contract.set_dumb_s_only(10));
-                client
-                    .call(&ink_e2e::alice(), _msg, 0, None)
-                    .await
-                    .expect("set_dumb_s_only failed")
-            };
-
-            assert!(matches!(result.return_value(), ()));
-
-            let result = {
-                let _msg = build_message::<ContractRef>(address.clone())
-                    .call(|contract| contract.return_dumb_s());
-                client
-                    .call(&ink_e2e::alice(), _msg, 0, None)
-                    .await
-                    .expect("return_dumb_s failed")
-            };
-
-            assert!(matches!(result.return_value(), 10));
-
-            Ok(())
-        }
-
-        #[ink_e2e::test]
-        async fn  only_get() -> E2EResult<()> {
-            let constructor = ContractRef::new(0);
-            let address = client
-                .instantiate("my_psp22", &ink_e2e::alice(), constructor, 0, None)
-                .await
-                .expect("instantiate failed")
-                .account_id;
-
-            let result = {
-                let _msg = build_message::<ContractRef>(address.clone())
-                    .call(|contract| contract.get_dumb_g_only());
-                client
-                    .call(&ink_e2e::alice(), _msg, 0, None)
-                    .await
-                    .expect("get_dumb_g_only failed")
-            };
-
-            assert!(matches!(result.return_value(), 0));
-
-            let result = {
-                let _msg = build_message::<ContractRef>(address.clone())
-                    .call(|contract| contract.update_dumb_g(10));
-                client
-                    .call(&ink_e2e::alice(), _msg, 0, None)
-                    .await
-                    .expect("update_dumb_g_only failed")
-            };
-
-            assert!(matches!(result.return_value(), ()));
-
-            let result = {
-                let _msg = build_message::<ContractRef>(address.clone())
-                    .call(|contract| contract.get_dumb_g_only());
-                client
-                    .call(&ink_e2e::alice(), _msg, 0, None)
-                    .await
-                    .expect("get_dumb_g_only failed")
-            };
-
-            assert!(matches!(result.return_value(), 10));
 
             Ok(())
         }

--- a/examples/psp22/lib.rs
+++ b/examples/psp22/lib.rs
@@ -9,7 +9,6 @@ pub mod my_psp22 {
         contracts::psp22::*,
         traits::{
             Storage,
-            StorageAsMut,
             String,
         },
     };
@@ -19,24 +18,24 @@ pub mod my_psp22 {
     pub struct Contract {
         #[storage_field]
         psp22: psp22::Data,
-        // fields for hater logic
+        // fields for hater storage
         #[storage_field]
-        hated_logic: HatedLogic,
+        hated_storage: HatedStorage,
     }
 
     #[openbrush::upgradeable_storage(STORAGE_KEY)]
-    #[openbrush::accessors(HatedLogicAccessors)]
+    #[openbrush::accessors(HatedStorageAccessors)]
     #[derive(Storage)]
     #[derive(Debug)]
-    pub struct HatedLogic {
+    pub struct HatedStorage {
         #[get]
         #[set]
         hated_account: AccountId,
     }
 
-    pub const STORAGE_KEY: u32 = openbrush::storage_unique_key!(HatedLogic);
+    pub const STORAGE_KEY: u32 = openbrush::storage_unique_key!(HatedStorage);
 
-    impl HatedLogicAccessors for Contract {}
+    impl HatedStorageAccessors for Contract {}
 
     impl Transfer for Contract {
         // Let's override method to reject transactions to bad account
@@ -46,7 +45,7 @@ pub mod my_psp22 {
             to: Option<&AccountId>,
             _amount: &Balance,
         ) -> Result<(), PSP22Error> {
-            if to == Some(&self.data::<HatedLogic>().hated_account) {
+            if to == Some(&self.hated_storage.hated_account) {
                 return Err(PSP22Error::Custom(String::from("I hate this account!")))
             }
             Ok(())
@@ -60,7 +59,7 @@ pub mod my_psp22 {
         pub fn new(total_supply: Balance) -> Self {
             let mut instance = Self {
                 psp22: Default::default(),
-                hated_logic: HatedLogic {
+                hated_storage: HatedStorage {
                     hated_account: [255; 32].into(),
                 },
             };
@@ -76,7 +75,7 @@ pub mod my_psp22 {
     #[cfg(all(test, feature = "e2e-tests"))]
     pub mod tests {
         use openbrush::contracts::psp22::psp22_external::PSP22;
-        use crate::my_psp22::hatedlogicaccessors_external::HatedLogicAccessors;
+        use crate::my_psp22::hatedstorageaccessors_external::HatedStorageAccessors;
         #[rustfmt::skip]
         use super::*;
         #[rustfmt::skip]

--- a/examples/psp22/lib.rs
+++ b/examples/psp22/lib.rs
@@ -268,5 +268,49 @@ pub mod my_psp22 {
             Ok(())
         }
 
+        #[ink_e2e::test]
+        async fn  only_get() -> E2EResult<()> {
+            let constructor = ContractRef::new(0);
+            let address = client
+                .instantiate("my_psp22", &ink_e2e::alice(), constructor, 0, None)
+                .await
+                .expect("instantiate failed")
+                .account_id;
+
+            let result = {
+                let _msg = build_message::<ContractRef>(address.clone())
+                    .call(|contract| contract.get_dumb_g_only());
+                client
+                    .call(&ink_e2e::alice(), _msg, 0, None)
+                    .await
+                    .expect("get_dumb_g_only failed")
+            };
+
+            assert!(matches!(result.return_value(), 0));
+
+            let result = {
+                let _msg = build_message::<ContractRef>(address.clone())
+                    .call(|contract| contract.update_dumb_g(10));
+                client
+                    .call(&ink_e2e::alice(), _msg, 0, None)
+                    .await
+                    .expect("update_dumb_g_only failed")
+            };
+
+            assert!(matches!(result.return_value(), ()));
+
+            let result = {
+                let _msg = build_message::<ContractRef>(address.clone())
+                    .call(|contract| contract.get_dumb_g_only());
+                client
+                    .call(&ink_e2e::alice(), _msg, 0, None)
+                    .await
+                    .expect("get_dumb_g_only failed")
+            };
+
+            assert!(matches!(result.return_value(), 10));
+
+            Ok(())
+        }
     }
 }

--- a/lang/codegen/src/accessors.rs
+++ b/lang/codegen/src/accessors.rs
@@ -149,7 +149,7 @@ fn extract_get_fields(s: synstructure::Structure) -> Vec<Field> {
     struct_item
         .fields
         .iter()
-        .filter(|field| field.attrs.iter().find(|a| a.path.is_ident("get")).is_some())
+        .filter(|field| field.attrs.iter().any(|a| a.path.is_ident("get")))
         .cloned()
         .collect::<Vec<_>>()
 }
@@ -163,7 +163,7 @@ fn extract_set_fields(s: synstructure::Structure) -> Vec<Field> {
     struct_item
         .fields
         .iter()
-        .filter(|field| field.attrs.iter().find(|a| a.path.is_ident("set")).is_some())
+        .filter(|field| field.attrs.iter().any(|a| a.path.is_ident("set")))
         .cloned()
         .collect::<Vec<_>>()
 }

--- a/lang/macro/src/lib.rs
+++ b/lang/macro/src/lib.rs
@@ -482,7 +482,7 @@ synstructure::decl_attribute!(
     /// Macro that automatically implements accessors like get/set for struct fields, that implements scale::Encode
     /// and scale::Decode traits. You should specify the getters trait naming in the macro's attribute.
     /// Also, fields that you want getters to be generated, should be marked by `#[get]` attribute.
-    /// FIelds, that you want setters to be generated, should be marked by `#[set]` attribute.
+    /// Fields, that you want setters to be generated, should be marked by `#[set]` attribute.
     /// The name of the accessor message will be concatenation of `get/set` + `_` + field's name.
     ///
     /// # Example:


### PR DESCRIPTION
!NOTE
This PR goes into #61 , not `main`

- Add accessors_attr example code that demonstrates the new `accessors` macro
- Fix compilation of e2e tests so they could at least be compiled from the 2nd time
- Fix typos and other minor bugs