### PR TITLE
`non-upgradeable-lazy` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ crypto = ["openbrush_contracts/crypto"]
 nonces = ["openbrush_contracts/nonces"]
 checkpoints = ["openbrush_contracts/checkpoints"]
 non-upgradeable-lazy = ["openbrush_contracts/non-upgradeable-lazy"]
-psp61 = ["openbrush_contracts/psp61"
+psp61 = ["openbrush_contracts/psp61"]
 
 test-all = [
     "psp22",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ governance = ["openbrush_contracts/governance", "openbrush_contracts/checkpoints
 crypto = ["openbrush_contracts/crypto"]
 nonces = ["openbrush_contracts/nonces"]
 checkpoints = ["openbrush_contracts/checkpoints"]
+non-upgradeable-lazy = ["openbrush_contracts/non-upgradeable-lazy"]
 
 test-all = [
     "psp22",

--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -20,7 +20,7 @@ scale = { package = "parity-scale-codec", version = "3", default-features = fals
 scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 
-openbrush = { version = "~4.0.0-beta.1", package = "openbrush_lang", path = "../lang", default-features = false, features = ["crypto", "checkpoints"] }
+openbrush = { version = "~4.0.0-beta.1", package = "openbrush_lang", path = "../lang", default-features = false, features = ["crypto", "checkpoints", "non-upgradeable-lazy"] }
 
 pallet-assets-chain-extension = { git = "https://github.com/Brushfam/pallet-assets-chain-extension", branch = "polkadot-v0.9.37", default-features = false, features = ["ink-lang"]  }
 
@@ -68,6 +68,7 @@ upgradeable = ["ownable"]
 crypto = ["openbrush/crypto"]
 nonces = []
 checkpoints = ["openbrush/checkpoints"]
+non-upgradeable-lazy = ["openbrush/non-upgradeable-lazy"]
 test-all = [
     "psp22",
     "psp34",

--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -20,7 +20,7 @@ scale = { package = "parity-scale-codec", version = "3", default-features = fals
 scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 
-openbrush = { version = "~4.0.0-beta.1", package = "openbrush_lang", path = "../lang", default-features = false, features = ["crypto", "checkpoints", "non-upgradeable-lazy"] }
+openbrush = { version = "~4.0.0-beta.1", package = "openbrush_lang", path = "../lang", default-features = false, features = ["crypto", "checkpoints"] }
 
 pallet-assets-chain-extension = { git = "https://github.com/Brushfam/pallet-assets-chain-extension", branch = "polkadot-v0.9.37", default-features = false, features = ["ink-lang"]  }
 
@@ -68,7 +68,7 @@ upgradeable = ["ownable"]
 crypto = ["openbrush/crypto"]
 nonces = []
 checkpoints = ["openbrush/checkpoints"]
-non-upgradeable-lazy = ["openbrush/non-upgradeable-lazy"]
+non-upgradeable-lazy = []
 test-all = [
     "psp22",
     "psp34",

--- a/contracts/src/access/access_control/access_control.rs
+++ b/contracts/src/access/access_control/access_control.rs
@@ -40,7 +40,8 @@ use openbrush::{
 };
 
 #[derive(Default, Debug)]
-#[openbrush::storage_item]
+#[cfg_attr(feature = "non-upgradeable-lazy", openbrush::storage_item(lazy = false))]
+#[cfg_attr(not(feature = "non-upgradeable-lazy"), openbrush::storage_item)]
 pub struct Data {
     pub admin_roles: Mapping<RoleType, RoleType, ValueGuard<RoleType>>,
     pub members: Mapping<(RoleType, Option<AccountId>), (), MembersKey>,

--- a/contracts/src/access/access_control/extensions/enumerable.rs
+++ b/contracts/src/access/access_control/extensions/enumerable.rs
@@ -45,7 +45,8 @@ use openbrush::{
 };
 
 #[derive(Default, Debug)]
-#[openbrush::storage_item]
+#[cfg_attr(feature = "non-upgradeable-lazy", openbrush::storage_item(lazy = false))]
+#[cfg_attr(not(feature = "non-upgradeable-lazy"), openbrush::storage_item)]
 pub struct Data {
     pub admin_roles: Mapping<RoleType, RoleType, ValueGuard<RoleType>>,
     pub role_members: MultiMapping<RoleType, Option<AccountId>, ValueGuard<RoleType>>,

--- a/contracts/src/access/ownable/mod.rs
+++ b/contracts/src/access/ownable/mod.rs
@@ -34,7 +34,8 @@ use openbrush::{
 pub use ownable::Internal as _;
 
 #[derive(Default, Debug)]
-#[openbrush::storage_item]
+#[cfg_attr(feature = "non-upgradeable-lazy", openbrush::storage_item(lazy = false))]
+#[cfg_attr(not(feature = "non-upgradeable-lazy"), openbrush::storage_item)]
 pub struct Data {
     #[lazy]
     pub owner: Option<AccountId>,

--- a/contracts/src/finance/payment_splitter/mod.rs
+++ b/contracts/src/finance/payment_splitter/mod.rs
@@ -35,7 +35,8 @@ use openbrush::{
 pub use payment_splitter::Internal as _;
 
 #[derive(Default, Debug)]
-#[openbrush::storage_item]
+#[cfg_attr(feature = "non-upgradeable-lazy", openbrush::storage_item(lazy = false))]
+#[cfg_attr(not(feature = "non-upgradeable-lazy"), openbrush::storage_item)]
 pub struct Data {
     #[lazy]
     pub total_shares: Balance,

--- a/contracts/src/governance/extensions/governor_counting/data.rs
+++ b/contracts/src/governance/extensions/governor_counting/data.rs
@@ -30,7 +30,8 @@ pub use openbrush::{
 };
 
 #[derive(Default, Debug)]
-#[openbrush::storage_item]
+#[cfg_attr(feature = "non-upgradeable-lazy", openbrush::storage_item(lazy = false))]
+#[cfg_attr(not(feature = "non-upgradeable-lazy"), openbrush::storage_item)]
 pub struct Data {
     /// Stores the ammounts of the votes of the proposals
     /// The key is the proposal id and the value is the vote, which contains the ammount of votes

--- a/contracts/src/governance/extensions/governor_quorum/data.rs
+++ b/contracts/src/governance/extensions/governor_quorum/data.rs
@@ -23,7 +23,8 @@
 pub use openbrush::utils::checkpoints::Checkpoints;
 
 #[derive(Debug, Default)]
-#[openbrush::storage_item]
+#[cfg_attr(feature = "non-upgradeable-lazy", openbrush::storage_item(lazy = false))]
+#[cfg_attr(not(feature = "non-upgradeable-lazy"), openbrush::storage_item)]
 pub struct Data {
     /// Stores the quorum numerator history of the governor
     #[lazy]

--- a/contracts/src/governance/extensions/governor_settings/data.rs
+++ b/contracts/src/governance/extensions/governor_settings/data.rs
@@ -21,7 +21,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #[derive(Default, Debug)]
-#[openbrush::storage_item]
+#[cfg_attr(feature = "non-upgradeable-lazy", openbrush::storage_item(lazy = false))]
+#[cfg_attr(not(feature = "non-upgradeable-lazy"), openbrush::storage_item)]
 pub struct Data {
     /// The minimum number of votes required for a proposal to be accepted
     #[lazy]

--- a/contracts/src/governance/extensions/governor_votes/data.rs
+++ b/contracts/src/governance/extensions/governor_votes/data.rs
@@ -23,7 +23,8 @@
 pub use openbrush::traits::AccountId;
 
 #[derive(Debug, Default)]
-#[openbrush::storage_item]
+#[cfg_attr(feature = "non-upgradeable-lazy", openbrush::storage_item(lazy = false))]
+#[cfg_attr(not(feature = "non-upgradeable-lazy"), openbrush::storage_item)]
 pub struct Data {
     /// Stores the token of the `PSP22Votes` contract
     #[lazy]

--- a/contracts/src/governance/extensions/timelock_controller/mod.rs
+++ b/contracts/src/governance/extensions/timelock_controller/mod.rs
@@ -69,7 +69,8 @@ use openbrush::{
 pub use timelock_controller::Internal as _;
 
 #[derive(Default, Debug)]
-#[openbrush::storage_item]
+#[cfg_attr(feature = "non-upgradeable-lazy", openbrush::storage_item(lazy = false))]
+#[cfg_attr(not(feature = "non-upgradeable-lazy"), openbrush::storage_item)]
 pub struct Data {
     #[lazy]
     pub min_delay: Timestamp,

--- a/contracts/src/governance/governor/data.rs
+++ b/contracts/src/governance/governor/data.rs
@@ -38,7 +38,8 @@ pub use openbrush::{
 };
 
 #[derive(Default, Debug)]
-#[openbrush::storage_item]
+#[cfg_attr(feature = "non-upgradeable-lazy", openbrush::storage_item(lazy = false))]
+#[cfg_attr(not(feature = "non-upgradeable-lazy"), openbrush::storage_item)]
 pub struct Data {
     /// Stores the proposals
     /// The key is the proposal id and the value is the proposal core

--- a/contracts/src/governance/utils/votes/data.rs
+++ b/contracts/src/governance/utils/votes/data.rs
@@ -27,7 +27,8 @@ use openbrush::{
 };
 
 #[derive(Default, Debug)]
-#[openbrush::storage_item]
+#[cfg_attr(feature = "non-upgradeable-lazy", openbrush::storage_item(lazy = false))]
+#[cfg_attr(not(feature = "non-upgradeable-lazy"), openbrush::storage_item)]
 pub struct Data {
     /// Stores the delegations of the governor.
     /// The key is the delegator and the value is the delegatee

--- a/contracts/src/security/pausable/mod.rs
+++ b/contracts/src/security/pausable/mod.rs
@@ -38,7 +38,8 @@ pub use pausable::{
 };
 
 #[derive(Default, Debug)]
-#[openbrush::storage_item]
+#[cfg_attr(feature = "non-upgradeable-lazy", openbrush::storage_item(lazy = false))]
+#[cfg_attr(not(feature = "non-upgradeable-lazy"), openbrush::storage_item)]
 pub struct Data {
     #[lazy]
     pub paused: bool,

--- a/contracts/src/security/reentrancy_guard/mod.rs
+++ b/contracts/src/security/reentrancy_guard/mod.rs
@@ -30,7 +30,8 @@ use openbrush::{
 };
 
 #[derive(Default, Debug)]
-#[openbrush::storage_item]
+#[cfg_attr(feature = "non-upgradeable-lazy", openbrush::storage_item(lazy = false))]
+#[cfg_attr(not(feature = "non-upgradeable-lazy"), openbrush::storage_item)]
 pub struct Data {
     #[lazy]
     pub status: u8,

--- a/contracts/src/token/psp22/extensions/capped.rs
+++ b/contracts/src/token/psp22/extensions/capped.rs
@@ -40,7 +40,8 @@ pub use psp22::{
 };
 
 #[derive(Default, Debug)]
-#[openbrush::storage_item]
+#[cfg_attr(feature = "non-upgradeable-lazy", openbrush::storage_item(lazy = false))]
+#[cfg_attr(not(feature = "non-upgradeable-lazy"), openbrush::storage_item)]
 pub struct Data {
     #[lazy]
     pub cap: Balance,

--- a/contracts/src/token/psp22/extensions/metadata.rs
+++ b/contracts/src/token/psp22/extensions/metadata.rs
@@ -36,7 +36,8 @@ pub use psp22::{
 };
 
 #[derive(Default, Debug)]
-#[openbrush::storage_item]
+#[cfg_attr(feature = "non-upgradeable-lazy", openbrush::storage_item(lazy = false))]
+#[cfg_attr(not(feature = "non-upgradeable-lazy"), openbrush::storage_item)]
 pub struct Data {
     #[lazy]
     pub name: Option<String>,

--- a/contracts/src/token/psp22/extensions/permit.rs
+++ b/contracts/src/token/psp22/extensions/permit.rs
@@ -47,7 +47,8 @@ pub use psp22::{
 use scale::Encode;
 
 #[derive(Default, Debug)]
-#[openbrush::storage_item]
+#[cfg_attr(feature = "non-upgradeable-lazy", openbrush::storage_item(lazy = false))]
+#[cfg_attr(not(feature = "non-upgradeable-lazy"), openbrush::storage_item)]
 pub struct Data {
     #[lazy]
     pub cached_domain_separator: [u8; 32],

--- a/contracts/src/token/psp22/extensions/wrapper.rs
+++ b/contracts/src/token/psp22/extensions/wrapper.rs
@@ -45,7 +45,8 @@ pub use psp22::{
 pub use wrapper::Internal as _;
 
 #[derive(Default, Debug)]
-#[openbrush::storage_item]
+#[cfg_attr(feature = "non-upgradeable-lazy", openbrush::storage_item(lazy = false))]
+#[cfg_attr(not(feature = "non-upgradeable-lazy"), openbrush::storage_item)]
 pub struct Data {
     #[lazy]
     pub underlying: Option<AccountId>,

--- a/contracts/src/token/psp22/psp22.rs
+++ b/contracts/src/token/psp22/psp22.rs
@@ -42,7 +42,8 @@ pub use psp22::{
 };
 
 #[derive(Default, Debug)]
-#[openbrush::storage_item]
+#[cfg_attr(feature = "non-upgradeable-lazy", openbrush::storage_item(lazy = false))]
+#[cfg_attr(not(feature = "non-upgradeable-lazy"), openbrush::storage_item)]
 pub struct Data {
     #[lazy]
     pub supply: Balance,

--- a/contracts/src/token/psp22/utils/token_timelock.rs
+++ b/contracts/src/token/psp22/utils/token_timelock.rs
@@ -50,7 +50,8 @@ pub use token_timelock::{
 };
 
 #[derive(Default, Debug)]
-#[openbrush::storage_item]
+#[cfg_attr(feature = "non-upgradeable-lazy", openbrush::storage_item(lazy = false))]
+#[cfg_attr(not(feature = "non-upgradeable-lazy"), openbrush::storage_item)]
 pub struct Data {
     #[lazy]
     token: Option<AccountId>,

--- a/contracts/src/token/psp22_pallet/psp22_pallet.rs
+++ b/contracts/src/token/psp22_pallet/psp22_pallet.rs
@@ -44,7 +44,8 @@ pub use psp22_pallet::{
 };
 
 #[derive(Default, Debug)]
-#[openbrush::storage_item]
+#[cfg_attr(feature = "non-upgradeable-lazy", openbrush::storage_item(lazy = false))]
+#[cfg_attr(not(feature = "non-upgradeable-lazy"), openbrush::storage_item)]
 pub struct Data {
     /// Asset id of the token on the pallet.
     #[lazy]

--- a/contracts/src/token/psp34/extensions/enumerable.rs
+++ b/contracts/src/token/psp34/extensions/enumerable.rs
@@ -50,7 +50,8 @@ pub use psp34::{
 };
 
 #[derive(Default, Debug)]
-#[openbrush::storage_item]
+#[cfg_attr(feature = "non-upgradeable-lazy", openbrush::storage_item(lazy = false))]
+#[cfg_attr(not(feature = "non-upgradeable-lazy"), openbrush::storage_item)]
 pub struct Data {
     pub token_owner: Mapping<Id, Owner>,
     pub operator_approvals: Mapping<(Owner, Operator, Option<Id>), (), ApprovalsKey>,

--- a/contracts/src/token/psp34/extensions/metadata.rs
+++ b/contracts/src/token/psp34/extensions/metadata.rs
@@ -46,7 +46,8 @@ pub use psp34::{
 };
 
 #[derive(Default, Debug)]
-#[openbrush::storage_item]
+#[cfg_attr(feature = "non-upgradeable-lazy", openbrush::storage_item(lazy = false))]
+#[cfg_attr(not(feature = "non-upgradeable-lazy"), openbrush::storage_item)]
 pub struct Data {
     pub attributes: Mapping<(Id, String), String, AttributesKey>,
 }

--- a/contracts/src/token/psp34/psp34.rs
+++ b/contracts/src/token/psp34/psp34.rs
@@ -48,7 +48,8 @@ pub use psp34::{
 };
 
 #[derive(Default, Debug)]
-#[openbrush::storage_item]
+#[cfg_attr(feature = "non-upgradeable-lazy", openbrush::storage_item(lazy = false))]
+#[cfg_attr(not(feature = "non-upgradeable-lazy"), openbrush::storage_item)]
 pub struct Data {
     pub token_owner: Mapping<Id, Owner>,
     pub operator_approvals: Mapping<(Owner, Operator, Option<Id>), (), ApprovalsKey>,

--- a/contracts/src/token/psp37/extensions/enumerable.rs
+++ b/contracts/src/token/psp37/extensions/enumerable.rs
@@ -51,7 +51,8 @@ pub use psp37::{
 };
 
 #[derive(Default, Debug)]
-#[openbrush::storage_item]
+#[cfg_attr(feature = "non-upgradeable-lazy", openbrush::storage_item(lazy = false))]
+#[cfg_attr(not(feature = "non-upgradeable-lazy"), openbrush::storage_item)]
 pub struct Data {
     pub enumerable: MultiMapping<Option<AccountId>, Id, EnumerableKey>,
     pub balances: Mapping<(AccountId, Id), Balance, BalancesKey>,

--- a/contracts/src/token/psp37/extensions/metadata.rs
+++ b/contracts/src/token/psp37/extensions/metadata.rs
@@ -47,7 +47,8 @@ pub use psp37::{
 };
 
 #[derive(Default, Debug)]
-#[openbrush::storage_item]
+#[cfg_attr(feature = "non-upgradeable-lazy", openbrush::storage_item(lazy = false))]
+#[cfg_attr(not(feature = "non-upgradeable-lazy"), openbrush::storage_item)]
 pub struct Data {
     pub attributes: Mapping<(Id, String), String, AttributesKey>,
 }

--- a/contracts/src/token/psp37/psp37.rs
+++ b/contracts/src/token/psp37/psp37.rs
@@ -48,7 +48,8 @@ pub use psp37::{
 };
 
 #[derive(Default, Debug)]
-#[openbrush::storage_item]
+#[cfg_attr(feature = "non-upgradeable-lazy", openbrush::storage_item(lazy = false))]
+#[cfg_attr(not(feature = "non-upgradeable-lazy"), openbrush::storage_item)]
 pub struct Data {
     pub balances: Mapping<(AccountId, Option<Id>), Balance, BalancesKey>,
     pub supply: Mapping<Option<Id>, Balance, SupplyKey>,

--- a/contracts/src/upgradeability/diamond/diamond.rs
+++ b/contracts/src/upgradeability/diamond/diamond.rs
@@ -54,7 +54,8 @@ pub use ownable::Internal as _;
 
 // TODO: Add support of Erc165
 #[derive(Default, Debug)]
-#[openbrush::storage_item]
+#[cfg_attr(feature = "non-upgradeable-lazy", openbrush::storage_item(lazy = false))]
+#[cfg_attr(not(feature = "non-upgradeable-lazy"), openbrush::storage_item)]
 pub struct Data {
     pub selector_to_hash: Mapping<Selector, Hash>,
     // Facet mapped to all functions it supports

--- a/contracts/src/upgradeability/diamond/extensions/diamond_loupe.rs
+++ b/contracts/src/upgradeability/diamond/extensions/diamond_loupe.rs
@@ -51,7 +51,8 @@ pub use ownable::{
 };
 
 #[derive(Default, Debug)]
-#[openbrush::storage_item]
+#[cfg_attr(feature = "non-upgradeable-lazy", openbrush::storage_item(lazy = false))]
+#[cfg_attr(not(feature = "non-upgradeable-lazy"), openbrush::storage_item)]
 pub struct Data {
     // number of registered code hashes
     #[lazy]

--- a/contracts/src/upgradeability/proxy/mod.rs
+++ b/contracts/src/upgradeability/proxy/mod.rs
@@ -47,7 +47,8 @@ pub use proxy::{
 };
 
 #[derive(Default, Debug)]
-#[openbrush::storage_item]
+#[cfg_attr(feature = "non-upgradeable-lazy", openbrush::storage_item(lazy = false))]
+#[cfg_attr(not(feature = "non-upgradeable-lazy"), openbrush::storage_item)]
 pub struct Data {
     #[lazy]
     pub forward_to: Hash,

--- a/contracts/src/utils/nonces/nonces.rs
+++ b/contracts/src/utils/nonces/nonces.rs
@@ -33,7 +33,8 @@ use openbrush::{
 };
 
 #[derive(Default, Debug)]
-#[openbrush::storage_item]
+#[cfg_attr(feature = "non-upgradeable-lazy", openbrush::storage_item(lazy = false))]
+#[cfg_attr(not(feature = "non-upgradeable-lazy"), openbrush::storage_item)]
 pub struct Data {
     pub nonces: Mapping<AccountId, u64>,
 }

--- a/example_project_structure/impls/lending/data.rs
+++ b/example_project_structure/impls/lending/data.rs
@@ -15,7 +15,8 @@ use openbrush::{
 pub const STORAGE_KEY: u32 = openbrush::storage_unique_key!(Data);
 
 #[derive(Debug)]
-#[openbrush::storage_item]
+#[cfg_attr(feature = "non-upgradeable-lazy", openbrush::storage_item(lazy = false))]
+#[cfg_attr(not(feature = "non-upgradeable-lazy"), openbrush::storage_item)]
 /// define the struct with the data that our smart contract will be using
 /// this will isolate the logic of our smart contract from its storage
 pub struct Data {

--- a/lang/Cargo.toml
+++ b/lang/Cargo.toml
@@ -40,3 +40,4 @@ std = [
 ]
 checkpoints = []
 crypto = []
+non-upgradeable-lazy = ["openbrush_lang_macro/non-upgradeable-lazy"]

--- a/lang/Cargo.toml
+++ b/lang/Cargo.toml
@@ -40,4 +40,3 @@ std = [
 ]
 checkpoints = []
 crypto = []
-non-upgradeable-lazy = ["openbrush_lang_macro/non-upgradeable-lazy"]

--- a/lang/codegen/Cargo.toml
+++ b/lang/codegen/Cargo.toml
@@ -38,4 +38,3 @@ crate-type = [
 [features]
 default = ["std"]
 std = []
-non-upgradeable-lazy = []

--- a/lang/codegen/Cargo.toml
+++ b/lang/codegen/Cargo.toml
@@ -38,3 +38,4 @@ crate-type = [
 [features]
 default = ["std"]
 std = []
+non-upgradeable-lazy = []

--- a/lang/codegen/src/internal.rs
+++ b/lang/codegen/src/internal.rs
@@ -36,9 +36,11 @@ use syn::{
         Parse,
         ParseStream,
     },
+    punctuated::Punctuated,
     ItemImpl,
+    MetaNameValue,
+    Token,
 };
-
 pub(crate) const BRUSH_PREFIX: &str = "__openbrush";
 
 pub(crate) struct MetaList {
@@ -149,6 +151,28 @@ impl Parse for Attributes {
 impl Attributes {
     pub(crate) fn attr(&self) -> &Vec<syn::Attribute> {
         &self.0
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct Attribute {
+    args: Punctuated<MetaNameValue, Token![,]>,
+}
+
+impl IntoIterator for Attribute {
+    type Item = MetaNameValue;
+    type IntoIter = syn::punctuated::IntoIter<MetaNameValue>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.args.into_iter()
+    }
+}
+
+impl Parse for Attribute {
+    fn parse(input: ParseStream) -> Result<Self, syn::Error> {
+        Ok(Self {
+            args: Punctuated::parse_terminated(input)?,
+        })
     }
 }
 

--- a/lang/macro/Cargo.toml
+++ b/lang/macro/Cargo.toml
@@ -37,3 +37,5 @@ default = ["std"]
 std = [
     "openbrush_lang_codegen/std",
 ]
+non-upgradeable-lazy = [
+    "openbrush_lang_codegen/non-upgradeable-lazy"]

--- a/lang/macro/Cargo.toml
+++ b/lang/macro/Cargo.toml
@@ -37,5 +37,3 @@ default = ["std"]
 std = [
     "openbrush_lang_codegen/std",
 ]
-non-upgradeable-lazy = [
-    "openbrush_lang_codegen/non-upgradeable-lazy"]

--- a/lang/src/traits.rs
+++ b/lang/src/traits.rs
@@ -139,22 +139,20 @@ impl ConstHasher {
 
 #[derive(scale::Decode, scale::Encode, Default, Debug)]
 #[cfg_attr(feature = "std", derive(scale_info::TypeInfo, ink::storage::traits::StorageLayout))]
-pub struct MockLazy<T: Storable + Clone> {
-    value: Option<T>,
-}
+pub struct MockLazy<T: Storable + Clone>(T);
 
 impl<T: Storable + Clone> MockLazy<T> {
     pub fn get(&self) -> Option<T> {
-        self.value.clone()
+        Some(self.0.clone())
     }
 
     pub fn set(&mut self, value: &T) {
-        self.value = Some(value.clone());
+        self.0 = value.clone();
     }
 }
 
 impl<T: Storable + Clone + Default> MockLazy<T> {
     pub fn get_or_default(&self) -> T {
-        self.value.clone().unwrap_or_default()
+        self.0.clone()
     }
 }

--- a/lang/src/traits.rs
+++ b/lang/src/traits.rs
@@ -136,3 +136,25 @@ impl ConstHasher {
         xxh32(str.as_bytes(), XXH32_SEED)
     }
 }
+
+#[derive(scale::Decode, scale::Encode, Default, Debug)]
+#[cfg_attr(feature = "std", derive(scale_info::TypeInfo, ink::storage::traits::StorageLayout))]
+pub struct MockLazy<T: Storable + Clone> {
+    value: Option<T>,
+}
+
+impl<T: Storable + Clone> MockLazy<T> {
+    pub fn get(&self) -> Option<T> {
+        self.value.clone()
+    }
+
+    pub fn set(&mut self, value: &T) {
+        self.value = Some(value.clone());
+    }
+}
+
+impl<T: Storable + Clone + Default> MockLazy<T> {
+    pub fn get_or_default(&self) -> T {
+        self.value.clone().unwrap_or_default()
+    }
+}

--- a/tests/ui/accessors/fail/fail-without-args.rs
+++ b/tests/ui/accessors/fail/fail-without-args.rs
@@ -1,4 +1,5 @@
-#[openbrush::storage_item]
+#[cfg_attr(feature = "non-upgradeable-lazy", openbrush::storage_item(lazy = false))]
+#[cfg_attr(not(feature = "non-upgradeable-lazy"), openbrush::storage_item)]
 #[openbrush::accessors]
 #[derive(Default, Debug)]
 pub struct AccessData {

--- a/tests/ui/accessors/pass/correct.rs
+++ b/tests/ui/accessors/pass/correct.rs
@@ -2,7 +2,8 @@ use openbrush::traits::Storage;
 
 #[openbrush::accessors(AccessDataAccessors)]
 #[derive(Default, Debug)]
-#[openbrush::storage_item]
+#[cfg_attr(feature = "non-upgradeable-lazy", openbrush::storage_item(lazy = false))]
+#[cfg_attr(not(feature = "non-upgradeable-lazy"), openbrush::storage_item)]
 pub struct AccessData {
     #[get]
     #[set]

--- a/tests/ui/storage_item/pass/correct.rs
+++ b/tests/ui/storage_item/pass/correct.rs
@@ -1,15 +1,17 @@
 use openbrush::traits::AccountId;
 #[derive(Debug)]
-#[openbrush::storage_item]
+#[cfg_attr(feature = "non-upgradeable-lazy", openbrush::storage_item(lazy = false))]
+#[cfg_attr(not(feature = "non-upgradeable-lazy"), openbrush::storage_item)]
 pub struct OwnableData {
-   #[lazy]
-   pub owner: AccountId,
+    #[lazy]
+    pub owner: AccountId,
 }
 
 #[derive(Debug)]
-#[openbrush::storage_item]
+#[cfg_attr(feature = "non-upgradeable-lazy", openbrush::storage_item(lazy = false))]
+#[cfg_attr(not(feature = "non-upgradeable-lazy"), openbrush::storage_item)]
 pub struct ProxyData {
-   pub forward: AccountId,
+    pub forward: AccountId,
 }
 
 fn main() {}

--- a/typechain-compiler-config.json
+++ b/typechain-compiler-config.json
@@ -1,6 +1,6 @@
 {
   "projectFiles": [
-    "example_project_structure/contracts/**", "examples/**/Cargo.toml", "examples/**/**/Cargo.toml", "mocks/**"
+    "examples/diamond/**"
   ],
   "artifactsPath": "./artifacts",
   "typechainGeneratedPath": "./typechain-generated"


### PR DESCRIPTION
If the feature is enabled when you are building your contract, all the types that are marked with `lazy` attribute in `storage_item` macro will be wrapped in `MockLazy` type which is reducing contract size