### PR TITLE
Fix H01

### DIFF
--- a/contracts/src/token/psp22/extensions/capped.rs
+++ b/contracts/src/token/psp22/extensions/capped.rs
@@ -29,6 +29,7 @@ pub use crate::{
 };
 pub use capped::Internal as _;
 use openbrush::traits::{
+    AccountId,
     Balance,
     Storage,
     String,
@@ -79,5 +80,29 @@ pub trait InternalImpl: Storage<Data> + Internal + PSP22 {
 
     fn _cap(&self) -> Balance {
         self.data().cap.get_or_default()
+    }
+}
+
+pub trait PSP22TransferImpl: Internal {
+    fn _before_token_transfer(
+        &mut self,
+        _from: Option<&AccountId>,
+        _to: Option<&AccountId>,
+        _amount: &Balance,
+    ) -> Result<(), PSP22Error> {
+        if _from.is_none() && _to.is_some() && Internal::_is_cap_exceeded(self, _amount) {
+            return Err(PSP22Error::Custom(String::from("Cap exceeded")))
+        }
+
+        Ok(())
+    }
+
+    fn _after_token_transfer(
+        &mut self,
+        _from: Option<&AccountId>,
+        _to: Option<&AccountId>,
+        _amount: &Balance,
+    ) -> Result<(), PSP22Error> {
+        Ok(())
     }
 }

--- a/contracts/src/token/psp22/psp22.rs
+++ b/contracts/src/token/psp22/psp22.rs
@@ -142,23 +142,9 @@ pub trait Internal {
     fn _mint_to(&mut self, account: AccountId, amount: Balance) -> Result<(), PSP22Error>;
 
     fn _burn_from(&mut self, account: AccountId, amount: Balance) -> Result<(), PSP22Error>;
-
-    fn _before_token_transfer(
-        &mut self,
-        _from: Option<&AccountId>,
-        _to: Option<&AccountId>,
-        _amount: &Balance,
-    ) -> Result<(), PSP22Error>;
-
-    fn _after_token_transfer(
-        &mut self,
-        _from: Option<&AccountId>,
-        _to: Option<&AccountId>,
-        _amount: &Balance,
-    ) -> Result<(), PSP22Error>;
 }
 
-pub trait InternalImpl: Storage<Data> + Internal {
+pub trait InternalImpl: Storage<Data> + Internal + PSP22Transfer {
     fn _emit_transfer_event(&self, _from: Option<AccountId>, _to: Option<AccountId>, _amount: Balance) {}
 
     fn _emit_approval_event(&self, _owner: AccountId, _spender: AccountId, _amount: Balance) {}
@@ -188,14 +174,14 @@ pub trait InternalImpl: Storage<Data> + Internal {
             return Err(PSP22Error::InsufficientBalance)
         }
 
-        Internal::_before_token_transfer(self, Some(&from), Some(&to), &amount)?;
+        PSP22Transfer::_before_token_transfer(self, Some(&from), Some(&to), &amount)?;
 
         self.data().balances.insert(&from, &(from_balance - amount));
 
         let to_balance = Internal::_balance_of(self, &to);
         self.data().balances.insert(&to, &(to_balance + amount));
 
-        Internal::_after_token_transfer(self, Some(&from), Some(&to), &amount)?;
+        PSP22Transfer::_after_token_transfer(self, Some(&from), Some(&to), &amount)?;
         Internal::_emit_transfer_event(self, Some(from), Some(to), amount);
 
         Ok(())
@@ -208,7 +194,7 @@ pub trait InternalImpl: Storage<Data> + Internal {
     }
 
     fn _mint_to(&mut self, account: AccountId, amount: Balance) -> Result<(), PSP22Error> {
-        Internal::_before_token_transfer(self, None, Some(&account), &amount)?;
+        PSP22Transfer::_before_token_transfer(self, None, Some(&account), &amount)?;
         let mut new_balance = Internal::_balance_of(self, &account);
         new_balance += amount;
         self.data().balances.insert(&account, &new_balance);
@@ -216,7 +202,7 @@ pub trait InternalImpl: Storage<Data> + Internal {
         let new_supply = self.data().supply.get_or_default() + amount;
         self.data().supply.set(&new_supply);
 
-        Internal::_after_token_transfer(self, None, Some(&account), &amount)?;
+        PSP22Transfer::_after_token_transfer(self, None, Some(&account), &amount)?;
         Internal::_emit_transfer_event(self, None, Some(account), amount);
 
         Ok(())
@@ -229,7 +215,7 @@ pub trait InternalImpl: Storage<Data> + Internal {
             return Err(PSP22Error::InsufficientBalance)
         }
 
-        Internal::_before_token_transfer(self, Some(&account), None, &amount)?;
+        PSP22Transfer::_before_token_transfer(self, Some(&account), None, &amount)?;
 
         from_balance -= amount;
         self.data().balances.insert(&account, &from_balance);
@@ -237,12 +223,30 @@ pub trait InternalImpl: Storage<Data> + Internal {
         let new_supply = self.data().supply.get_or_default() - amount;
         self.data().supply.set(&new_supply);
 
-        Internal::_after_token_transfer(self, Some(&account), None, &amount)?;
+        PSP22Transfer::_after_token_transfer(self, Some(&account), None, &amount)?;
         Internal::_emit_transfer_event(self, Some(account), None, amount);
 
         Ok(())
     }
+}
 
+pub trait PSP22Transfer {
+    fn _before_token_transfer(
+        &mut self,
+        _from: Option<&AccountId>,
+        _to: Option<&AccountId>,
+        _amount: &Balance,
+    ) -> Result<(), PSP22Error>;
+
+    fn _after_token_transfer(
+        &mut self,
+        _from: Option<&AccountId>,
+        _to: Option<&AccountId>,
+        _amount: &Balance,
+    ) -> Result<(), PSP22Error>;
+}
+
+pub trait PSP22TransferImpl {
     fn _before_token_transfer(
         &mut self,
         _from: Option<&AccountId>,

--- a/examples/psp22/lib.rs
+++ b/examples/psp22/lib.rs
@@ -21,7 +21,6 @@ pub struct HatedStorage {
 #[openbrush::contract]
 pub mod my_psp22 {
     use crate::*;
-    use openbrush::traits::String;
 
     #[ink(storage)]
     #[derive(Storage)]

--- a/examples/psp22_extensions/capped/lib.rs
+++ b/examples/psp22_extensions/capped/lib.rs
@@ -3,10 +3,7 @@
 #[openbrush::implementation(PSP22, PSP22Capped, PSP22Mintable)]
 #[openbrush::contract]
 pub mod my_psp22_capped {
-    use openbrush::traits::{
-        Storage,
-        String,
-    };
+    use openbrush::traits::Storage;
 
     #[ink(storage)]
     #[derive(Default, Storage)]

--- a/lang/codegen/src/implementation.rs
+++ b/lang/codegen/src/implementation.rs
@@ -76,7 +76,7 @@ pub fn generate(attrs: TokenStream, ink_module: TokenStream) -> TokenStream {
 
     let mut impl_args = ImplArgs::new(&map, &mut items, &mut imports, &mut overriden_traits, ident);
 
-    for to_implement in args {
+    for to_implement in args.clone() {
         match to_implement.as_str() {
             "PSP22" => impl_psp22(&mut impl_args),
             "PSP22Mintable" => impl_psp22_mintable(&mut impl_args),
@@ -113,6 +113,10 @@ pub fn generate(attrs: TokenStream, ink_module: TokenStream) -> TokenStream {
             "Upgradeable" => impl_upgradeable(&mut impl_args),
             _ => panic!("openbrush::implementation({to_implement}) not implemented!"),
         }
+    }
+
+    if args.contains(&String::from("PSP22")) {
+        impl_psp22_transfer(&mut impl_args, args.contains(&String::from("PSP22Capped")));
     }
 
     cleanup_imports(impl_args.imports);

--- a/lang/codegen/src/implementations.rs
+++ b/lang/codegen/src/implementations.rs
@@ -101,24 +101,6 @@ pub(crate) fn impl_psp22(impl_args: &mut ImplArgs) {
             fn _burn_from(&mut self, account: AccountId, amount: Balance) -> Result<(), PSP22Error> {
                 psp22::InternalImpl::_burn_from(self, account, amount)
             }
-
-            fn _before_token_transfer(
-                &mut self,
-                from: Option<&AccountId>,
-                to: Option<&AccountId>,
-                amount: &Balance,
-            ) -> Result<(), PSP22Error> {
-                psp22::InternalImpl::_before_token_transfer(self, from, to, amount)
-            }
-
-            fn _after_token_transfer(
-                &mut self,
-                from: Option<&AccountId>,
-                to: Option<&AccountId>,
-                amount: &Balance,
-            ) -> Result<(), PSP22Error> {
-                psp22::InternalImpl::_after_token_transfer(self, from, to, amount)
-            }
         }
     ))
     .expect("Should parse");
@@ -293,6 +275,48 @@ pub(crate) fn impl_psp22_metadata(impl_args: &mut ImplArgs) {
 
     impl_args.items.push(syn::Item::Impl(metadata_impl));
     impl_args.items.push(syn::Item::Impl(metadata));
+}
+
+pub(crate) fn impl_psp22_transfer(impl_args: &mut ImplArgs, capped: bool) {
+    let storage_struct_name = impl_args.contract_name();
+
+    let implementation = if capped {
+        syn::parse2::<syn::ItemImpl>(quote!(
+            impl capped::PSP22TransferImpl for #storage_struct_name {}
+        ))
+        .expect("Should parse")
+    } else {
+        syn::parse2::<syn::ItemImpl>(quote!(
+            impl psp22::PSP22TransferImpl for #storage_struct_name {}
+        ))
+        .expect("Should parse")
+    };
+
+    let transfer = syn::parse2::<syn::ItemImpl>(quote!(
+        impl psp22::PSP22Transfer for #storage_struct_name {
+            fn _before_token_transfer(
+                &mut self,
+                _from: Option<&AccountId>,
+                _to: Option<&AccountId>,
+                _amount: &Balance,
+            ) -> Result<(), PSP22Error> {
+                PSP22TransferImpl::_before_token_transfer(self, _from, _to, _amount)
+            }
+
+            fn _after_token_transfer(
+                &mut self,
+                _from: Option<&AccountId>,
+                _to: Option<&AccountId>,
+                _amount: &Balance,
+            ) -> Result<(), PSP22Error> {
+                PSP22TransferImpl::_after_token_transfer(self, _from, _to, _amount)
+            }
+        }
+    ))
+    .expect("Should parse");
+
+    impl_args.items.push(syn::Item::Impl(implementation));
+    impl_args.items.push(syn::Item::Impl(transfer));
 }
 
 pub(crate) fn impl_psp22_capped(impl_args: &mut ImplArgs) {
@@ -834,24 +858,6 @@ pub(crate) fn impl_psp34(impl_args: &mut ImplArgs) {
 
             fn _check_token_exists(&self, id: &Id) -> Result<AccountId, PSP34Error> {
                 psp34::InternalImpl::_check_token_exists(self, id)
-            }
-
-            fn _before_token_transfer(
-                &mut self,
-                from: Option<&AccountId>,
-                to: Option<&AccountId>,
-                id: &Id,
-            ) -> Result<(), PSP34Error> {
-                psp34::InternalImpl::_before_token_transfer(self, from, to, id)
-            }
-
-            fn _after_token_transfer(
-                &mut self,
-                from: Option<&AccountId>,
-                to: Option<&AccountId>,
-                id: &Id,
-            ) -> Result<(), PSP34Error> {
-                psp34::InternalImpl::_after_token_transfer(self, from, to, id)
             }
         }
     ))


### PR DESCRIPTION
Separated _before_token_transfer and _after_token_transfer from Internal trait into PSP22Transfer and added different implementation that depends on whether Capped extension is enabled. (wrong commit message btw)